### PR TITLE
Fixed improperly labeled fields. Also made the DateTimeFormat examples link open to new window.

### DIFF
--- a/web/WebTemplate.htm
+++ b/web/WebTemplate.htm
@@ -338,12 +338,12 @@
 					</div>
 
 					<div class="form-row">
-						<div class="form-label"><span>Slideshow duration between slides (milliseconds) font size:</span></div>
+						<div class="form-label"><span>Slideshow duration between slides (milliseconds):</span></div>
 						<div class="form-input"><input type="text" name="slideshowduration" placeholder="30000" <!--SLIDESHOWDURATION--></div>
 					</div>
 
 					<div class="form-row">
-						<div class="form-label"><span>Transition duration during fades (milliseconds) font size:</span></div>
+						<div class="form-label"><span>Transition duration during fades (milliseconds):</span></div>
 						<div class="form-input"><input type="text" name="transitiontime" placeholder="1600" <!--TRANSITIONTIME--></div>
 					</div>
 					<!-- Infobar Settings -->
@@ -367,7 +367,7 @@
 
 
 					<div class="form-row">
-						<div class="form-label"><span>Date / Time Format <a href="https://www.c-sharpcorner.com/blogs/date-and-time-format-in-c-sharp-programming1">(examples here)</a></span></div>
+						<div class="form-label"><span>Date / Time Format <a href="https://www.c-sharpcorner.com/blogs/date-and-time-format-in-c-sharp-programming1" target="_blank">(examples here)</a></span></div>
 						<div class="form-input"><input type="text" name="DateTimeFormat" width="300" placeholder="H:mm tt" <!--DATETIMEFORMAT--></div>
 					</div>
 


### PR DESCRIPTION
WebTemplate.htm - Fixed improperly labeled fields. Also made the DateTimeFormat examples link open to new window.